### PR TITLE
Conditionally render list & add-item navlinks if token in localstorage

### DIFF
--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -24,9 +24,11 @@ export function Layout() {
 				</main>
 				<nav className="Nav">
 					<div className="Nav-container">
-						<NavLink to="/" className="Nav-link">
-							Home
-						</NavLink>
+						{!listToken ? (
+							<NavLink to="/" className="Nav-link">
+								Home
+							</NavLink>
+						) : null}
 						{listToken ? (
 							<NavLink to="/list" className="Nav-link">
 								List

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -11,6 +11,8 @@ import './Layout.css';
  */
 
 export function Layout() {
+	const listToken = localStorage.getItem('tcl-shopping-list-token');
+
 	return (
 		<>
 			<div className="Layout">
@@ -25,12 +27,16 @@ export function Layout() {
 						<NavLink to="/" className="Nav-link">
 							Home
 						</NavLink>
-						<NavLink to="/list" className="Nav-link">
-							List
-						</NavLink>
-						<NavLink to="/add-item" className="Nav-link">
-							Add Item
-						</NavLink>
+						{listToken ? (
+							<NavLink to="/list" className="Nav-link">
+								List
+							</NavLink>
+						) : null}
+						{listToken ? (
+							<NavLink to="/add-item" className="Nav-link">
+								Add Item
+							</NavLink>
+						) : null}
 					</div>
 				</nav>
 			</div>


### PR DESCRIPTION

## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
Conditionally renders `List` and `Add item` Nav links if a token is saved to local storage. The user will be able to access the `List` and `Add Item` pages only if they're 'logged in'.

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

- [ x ] Only show the `Home` page Nav link when a user hasn't created a list yet
- [ x ] Show the `Link` and `Add Item` Nav links when a user is logged into a list 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->
![Screen Shot 2023-09-27 at 11 38 45 AM](https://github.com/the-collab-lab/tcl-64-smart-shopping-list/assets/113865981/f63864c9-1fad-493f-b2ab-07671122e056)

### After

<!-- If UI feature, take provide screenshots -->
![Screen Shot 2023-09-27 at 11 39 28 AM](https://github.com/the-collab-lab/tcl-64-smart-shopping-list/assets/113865981/83e3c584-d668-45b2-9a85-5e4861c10649)

## Testing Steps / QA Criteria

1. Visit the `Home` page and ensure only that Nav link is visible at the bottom on the page.
2. After you've logged into a list, you should see the `List` and `Add Item` Nav links at the bottom of the page.

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
