### PR TITLE
Modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-rough-notation": "^1.0.5",
-				"react-router-dom": "^6.14.2"
+				"react-router-dom": "^6.14.2",
+				"tw-elements-react": "^1.0.0-alpha1"
 			},
 			"devDependencies": {
 				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -2134,6 +2135,26 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -5991,6 +6012,26 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+		},
 		"node_modules/@types/aria-query": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
@@ -6759,7 +6800,6 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -8026,6 +8066,11 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8283,6 +8328,14 @@
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.4.3",
@@ -12383,6 +12436,11 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+		},
 		"node_modules/makeerror": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -16387,6 +16445,53 @@
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
 			"dev": true
 		},
+		"node_modules/ts-node": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-node/node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -16436,6 +16541,17 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
+		},
+		"node_modules/tw-elements-react": {
+			"version": "1.0.0-alpha1",
+			"resolved": "https://registry.npmjs.org/tw-elements-react/-/tw-elements-react-1.0.0-alpha1.tgz",
+			"integrity": "sha512-SkiNnPqjdsBNwu6hGbgDvwp0F2jiyCxnJkaq1vy+RmAx1zny3yVlspMPcDmrJSOYxlXsbpJJOKrLxq0Wxr3FXg==",
+			"dependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0",
+				"react-router-dom": "^6.11.1",
+				"ts-node": "^10.9.1"
+			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -16538,7 +16654,6 @@
 			"version": "5.1.6",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
 			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-			"dev": true,
 			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -16747,6 +16862,11 @@
 			"engines": {
 				"node": ">= 0.4.0"
 			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
 		},
 		"node_modules/vary": {
 			"version": "1.1.2",
@@ -17822,6 +17942,14 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-rough-notation": "^1.0.5",
-		"react-router-dom": "^6.14.2"
+		"react-router-dom": "^6.14.2",
+		"tw-elements-react": "^1.0.0-alpha1"
 	},
 	"devDependencies": {
 		"@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,12 @@ export function App() {
 						path="/list"
 						element={
 							listToken ? (
-								<List data={data} listId={listToken} />
+								<List
+									data={data}
+									listId={listToken}
+									showModal={showModal}
+									setShowModal={setShowModal}
+								/>
 							) : (
 								<Navigate to="/" />
 							)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,8 +49,8 @@ export function App() {
 					path="/"
 					element={
 						<Layout
+							listToken={listToken}
 							setListToken={setListToken}
-							listId={listToken}
 							showModal={showModal}
 							setShowModal={setShowModal}
 						/>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import {
 	Route,
 	Navigate,
 } from 'react-router-dom';
+import { useState } from 'react';
 
 import { AddItem, Home, Layout, List } from './views';
 
@@ -14,6 +15,8 @@ import { useStateWithStorage } from './utils';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 
 export function App() {
+	const [showModal, setShowModal] = useState(false);
+
 	/**
 	 * This custom hook takes a token pointing to a shopping list
 	 * in our database and syncs it with localStorage for later use.
@@ -44,7 +47,14 @@ export function App() {
 			<Routes>
 				<Route
 					path="/"
-					element={<Layout setListToken={setListToken} listId={listToken} />}
+					element={
+						<Layout
+							setListToken={setListToken}
+							listId={listToken}
+							showModal={showModal}
+							setShowModal={setShowModal}
+						/>
+					}
 				>
 					<Route
 						index

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,6 @@ import {
 	Route,
 	Navigate,
 } from 'react-router-dom';
-import { useState } from 'react';
 
 import { AddItem, Home, Layout, List } from './views';
 
@@ -15,8 +14,6 @@ import { useStateWithStorage } from './utils';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 
 export function App() {
-	const [showModal, setShowModal] = useState(false);
-
 	/**
 	 * This custom hook takes a token pointing to a shopping list
 	 * in our database and syncs it with localStorage for later use.
@@ -47,14 +44,7 @@ export function App() {
 			<Routes>
 				<Route
 					path="/"
-					element={
-						<Layout
-							listToken={listToken}
-							setListToken={setListToken}
-							showModal={showModal}
-							setShowModal={setShowModal}
-						/>
-					}
+					element={<Layout listToken={listToken} setListToken={setListToken} />}
 				>
 					<Route
 						index
@@ -70,12 +60,7 @@ export function App() {
 						path="/list"
 						element={
 							listToken ? (
-								<List
-									data={data}
-									listId={listToken}
-									showModal={showModal}
-									setShowModal={setShowModal}
-								/>
+								<List data={data} listId={listToken} />
 							) : (
 								<Navigate to="/" />
 							)

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -7,10 +7,10 @@ const Button = ({ text, variant, type, onClick, withIcon, className }) => {
 	const variantClasses = {
 		primary:
 			'bg-green dark:bg-light-blue text-white hover:bg-green-dark active:scale-105 dark:text-black px-32 py-4',
-		secondaryConfirm:
-			'bg-light-blue border dark:bg-green-dark dark:border-hidden dark:text-black text-black hover:bg-green-dark dark:bg-green-dark hover:dark:bg-yellow active:scale-105 px-16 py-4',
-		secondaryCancel:
-			'bg-white border text-black hover:bg-gray-400 dark:text-black dark:bg-gray-300 dark:border-hidden active:scale-105 px-16 py-4',
+		primarySmall:
+			'bg-green dark:bg-black text-white dark:text-light-blue hover:dark:text-black hover:bg-green-dark active:scale-105 dark:text-black px-16 py-4',
+		secondary:
+			'bg-white dark:bg-white text-black hover:bg-gray-200 border dark:border-hidden active:scale-105 px-16 py-4',
 	};
 	const classes = classnames(
 		'rounded-full transition duration-300 focus:outline-none',

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -8,9 +8,9 @@ const Button = ({ text, variant, type, onClick, withIcon, className }) => {
 		primary:
 			'bg-green dark:bg-light-blue text-white hover:bg-green-dark active:scale-105 dark:text-black px-32 py-4',
 		secondaryConfirm:
-			'bg-light-blue border dark:bg-light-blue dark:border-hidden dark:text-black text-black hover:bg-green-dark dark:bg-gray-700 active:scale-105 px-24 py-4',
+			'bg-light-blue border dark:bg-light-blue dark:border-hidden dark:text-black text-black hover:bg-green-dark dark:bg-green-dark hover:dark:bg-yellow active:scale-105 px-16 py-4',
 		secondaryCancel:
-			'bg-white border text-black hover:bg-gray-400 dark:text-white dark:bg-gray-700 active:scale-105 px-16 py-4',
+			'bg-white border text-black hover:bg-gray-400 dark:text-black dark:bg-gray-300 dark:border-hidden active:scale-105 px-16 py-4',
 	};
 	const classes = classnames(
 		'rounded-full transition duration-300 focus:outline-none',

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -8,7 +8,7 @@ const Button = ({ text, variant, type, onClick, withIcon, className }) => {
 		primary:
 			'bg-green dark:bg-light-blue text-white hover:bg-green-dark active:scale-105 dark:text-black px-32 py-4',
 		secondaryConfirm:
-			'bg-light-blue border dark:bg-light-blue dark:border-hidden dark:text-black text-black hover:bg-green-dark dark:bg-green-dark hover:dark:bg-yellow active:scale-105 px-16 py-4',
+			'bg-light-blue border dark:bg-green-dark dark:border-hidden dark:text-black text-black hover:bg-green-dark dark:bg-green-dark hover:dark:bg-yellow active:scale-105 px-16 py-4',
 		secondaryCancel:
 			'bg-white border text-black hover:bg-gray-400 dark:text-black dark:bg-gray-300 dark:border-hidden active:scale-105 px-16 py-4',
 	};

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,6 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
-import { updateItem, deleteItem } from '../api/firebase';
+import { updateItem } from '../api/firebase';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrashCan as trash } from '@fortawesome/free-regular-svg-icons';
 
@@ -52,12 +52,6 @@ export function ListItem({
 		setIsChecked(true);
 	};
 
-	// const handleDelete = async () => {
-	// 	if (window.confirm('Are you sure you want to delete this item?')) {
-	// 		await deleteItem(listId, itemId);
-	// 	}
-	// };
-
 	return (
 		<li className="ListItem">
 			<label className="ListItem-label">
@@ -73,9 +67,8 @@ export function ListItem({
 			</label>
 			&nbsp;
 			<button
-				onClick={(e) => {
-					setItemToDelete(itemId);
-					console.log(itemId);
+				onClick={() => {
+					setItemToDelete({ itemId: itemId, name: name });
 					setShowModal(true);
 				}}
 			>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -13,6 +13,8 @@ export function ListItem({
 	dateNextPurchased,
 	dateCreated,
 	urgency,
+	setShowModal,
+	setItemToDelete,
 }) {
 	const [isChecked, setIsChecked] = useState(false);
 
@@ -50,11 +52,19 @@ export function ListItem({
 		setIsChecked(true);
 	};
 
-	const handleDelete = async () => {
-		if (window.confirm('Are you sure you want to delete this item?')) {
-			await deleteItem(listId, itemId);
-		}
-	};
+	const modalBody = (
+		<>
+			Are you sure you want to delete this item?
+			<br />
+			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+		</>
+	);
+
+	// const handleDelete = async () => {
+	// 	if (window.confirm('Are you sure you want to delete this item?')) {
+	// 		await deleteItem(listId, itemId);
+	// 	}
+	// };
 
 	return (
 		<li className="ListItem">
@@ -70,7 +80,13 @@ export function ListItem({
 				<code className="ListItem-urgency">{urgency}</code>
 			</label>
 			&nbsp;
-			<button onClick={handleDelete}>
+			<button
+				onClick={(e) => {
+					setItemToDelete(itemId);
+					console.log(itemId);
+					setShowModal(true);
+				}}
+			>
 				<FontAwesomeIcon icon={trash} title="Delete item" />
 			</button>
 		</li>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,8 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem, deleteItem } from '../api/firebase';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrashCan as trash } from '@fortawesome/free-regular-svg-icons';
 
 export function ListItem({
 	name,
@@ -68,7 +70,9 @@ export function ListItem({
 				<code className="ListItem-urgency">{urgency}</code>
 			</label>
 			&nbsp;
-			<button onClick={handleDelete}>Delete</button>
+			<button onClick={handleDelete}>
+				<FontAwesomeIcon icon={trash} title="Delete item" />
+			</button>
 		</li>
 	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -52,14 +52,6 @@ export function ListItem({
 		setIsChecked(true);
 	};
 
-	const modalBody = (
-		<>
-			Are you sure you want to delete this item?
-			<br />
-			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
-		</>
-	);
-
 	// const handleDelete = async () => {
 	// 	if (window.confirm('Are you sure you want to delete this item?')) {
 	// 		await deleteItem(listId, itemId);

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -36,22 +36,6 @@ export function Modal({
 									className="text-2xl mb-3 ml-2 sm:ml-3"
 								/>
 							</div>
-							{/* <div className="flex justify-center bg-green pt-8 px-8">
-								<button
-									type="button"
-									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
-									onClick={() => setShowModal(false)}
-								>
-									Cancel
-								</button>
-								<button
-									type="button"
-									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
-									onClick={confirmationAction}
-								>
-									Confirm
-								</button>
-							</div> */}
 						</TEModalBody>
 					</TEModalContent>
 				</TEModalDialog>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -4,7 +4,6 @@ import {
 	TEModalDialog,
 	TEModalContent,
 	TEModalBody,
-	TEModalFooter,
 } from 'tw-elements-react';
 
 export function Modal({
@@ -16,29 +15,28 @@ export function Modal({
 	return (
 		<div>
 			<TEModal show={showModal} setShow={setShowModal}>
-				<TEModalDialog>
-					<TEModalContent>
-						<TEModalBody className="flex justify-center">
-							{/* <!--TODO: Finish styling after merging button & input components --> */}
+				<TEModalDialog className="pt-64 px-10">
+					<TEModalContent className="rounded-3xl">
+						<TEModalBody className="flex flex-col justify-center bg-green rounded-2xl p-10">
 							{modalBody}
+							{/* <!--TODO: Finish styling after merging button component --> */}
+							<div className="flex justify-center bg-green pt-8 px-8">
+								<button
+									type="button"
+									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
+									onClick={() => setShowModal(false)}
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
+									onClick={confirmationAction}
+								>
+									Confirm
+								</button>
+							</div>
 						</TEModalBody>
-						<TEModalFooter className="justify-center">
-							{/* <!--TODO: Finish styling after merging button & input components --> */}
-							<button
-								type="button"
-								className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
-								onClick={() => setShowModal(false)}
-							>
-								Cancel
-							</button>
-							<button
-								type="button"
-								className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
-								onClick={confirmationAction}
-							>
-								Confirm
-							</button>
-						</TEModalFooter>
 					</TEModalContent>
 				</TEModalDialog>
 			</TEModal>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -9,20 +9,24 @@ import {
 	TEModalFooter,
 } from 'tw-elements-react';
 
-export function Modal({ showModal, setShowModal, confirmationAction }) {
+export function Modal({
+	showModal,
+	setShowModal,
+	modalBody,
+	confirmationAction,
+}) {
 	return (
 		<div>
-			{/* <!-- Modal --> */}
 			<TEModal show={showModal} setShow={setShowModal}>
 				<TEModalDialog>
 					<TEModalContent>
-						<TEModalHeader>
-							{/* <!--Modal title--> */}
-							<h5 className="text-xl font-medium leading-normal text-neutral-800 dark:text-neutral-200">
-								Modal title
-							</h5>
-							{/* <!--Close button--> */}
-							<button
+						{/* <TEModalHeader> */}
+						{/* <!--Modal title--> */}
+						{/* <h5 className="text-xl font-medium leading-normal text-neutral-800 dark:text-neutral-200">
+								Please confirm
+							</h5> */}
+						{/* <!--Close button--> */}
+						{/* <button
 								type="button"
 								className="box-content rounded-none border-none hover:no-underline hover:opacity-75 focus:opacity-100 focus:shadow-none focus:outline-none"
 								onClick={() => setShowModal(false)}
@@ -42,29 +46,28 @@ export function Modal({ showModal, setShowModal, confirmationAction }) {
 										d="M6 18L18 6M6 6l12 12"
 									/>
 								</svg>
-							</button>
-						</TEModalHeader>
+							</button> */}
+						{/* </TEModalHeader> */}
 						{/* <!--Modal body--> */}
-						<TEModalBody>Are you sure you want to leave this list?</TEModalBody>
-						<TEModalFooter>
-							<TERipple rippleColor="light">
-								<button
-									type="button"
-									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
-									onClick={() => setShowModal(false)}
-								>
-									Cancel
-								</button>
-							</TERipple>
-							<TERipple rippleColor="light">
-								<button
-									type="button"
-									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
-									onClick={confirmationAction}
-								>
-									Confirm
-								</button>
-							</TERipple>
+						<TEModalBody className="flex justify-center">
+							{modalBody}
+						</TEModalBody>
+						<TEModalFooter className="justify-center">
+							{/* <!--TODO: Style buttons after merging button component --> */}
+							<button
+								type="button"
+								className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
+								onClick={() => setShowModal(false)}
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
+								onClick={confirmationAction}
+							>
+								Confirm
+							</button>
 						</TEModalFooter>
 					</TEModalContent>
 				</TEModalDialog>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import {
-	TERipple,
 	TEModal,
 	TEModalDialog,
 	TEModalContent,
-	TEModalHeader,
 	TEModalBody,
 	TEModalFooter,
 } from 'tw-elements-react';
@@ -20,35 +18,6 @@ export function Modal({
 			<TEModal show={showModal} setShow={setShowModal}>
 				<TEModalDialog>
 					<TEModalContent>
-						{/* <TEModalHeader> */}
-						{/* <!--Modal title--> */}
-						{/* <h5 className="text-xl font-medium leading-normal text-neutral-800 dark:text-neutral-200">
-								Please confirm
-							</h5> */}
-						{/* <!--Close button--> */}
-						{/* <button
-								type="button"
-								className="box-content rounded-none border-none hover:no-underline hover:opacity-75 focus:opacity-100 focus:shadow-none focus:outline-none"
-								onClick={() => setShowModal(false)}
-								aria-label="Close"
-							>
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									fill="none"
-									viewBox="0 0 24 24"
-									strokeWidth="1.5"
-									stroke="currentColor"
-									className="h-6 w-6"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										d="M6 18L18 6M6 6l12 12"
-									/>
-								</svg>
-							</button> */}
-						{/* </TEModalHeader> */}
-						{/* <!--Modal body--> */}
 						<TEModalBody className="flex justify-center">
 							{/* <!--TODO: Finish styling after merging button & input components --> */}
 							{modalBody}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -50,10 +50,11 @@ export function Modal({
 						{/* </TEModalHeader> */}
 						{/* <!--Modal body--> */}
 						<TEModalBody className="flex justify-center">
+							{/* <!--TODO: Finish styling after merging button & input components --> */}
 							{modalBody}
 						</TEModalBody>
 						<TEModalFooter className="justify-center">
-							{/* <!--TODO: Style buttons after merging button component --> */}
+							{/* <!--TODO: Finish styling after merging button & input components --> */}
 							<button
 								type="button"
 								className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import {
+	TERipple,
+	TEModal,
+	TEModalDialog,
+	TEModalContent,
+	TEModalHeader,
+	TEModalBody,
+	TEModalFooter,
+} from 'tw-elements-react';
+
+export default function Modal() {
+	const [showModal, setShowModal] = useState(false);
+
+	return (
+		<div>
+			{/* <!-- Button trigger modal --> */}
+			<TERipple rippleColor="white">
+				<button
+					type="button"
+					className="inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
+					onClick={() => setShowModal(true)}
+				>
+					Launch demo modal
+				</button>
+			</TERipple>
+
+			{/* <!-- Modal --> */}
+			<TEModal show={showModal} setShow={setShowModal}>
+				<TEModalDialog>
+					<TEModalContent>
+						<TEModalHeader>
+							{/* <!--Modal title--> */}
+							<h5 className="text-xl font-medium leading-normal text-neutral-800 dark:text-neutral-200">
+								Modal title
+							</h5>
+							{/* <!--Close button--> */}
+							<button
+								type="button"
+								className="box-content rounded-none border-none hover:no-underline hover:opacity-75 focus:opacity-100 focus:shadow-none focus:outline-none"
+								onClick={() => setShowModal(false)}
+								aria-label="Close"
+							>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth="1.5"
+									stroke="currentColor"
+									className="h-6 w-6"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							</button>
+						</TEModalHeader>
+						{/* <!--Modal body--> */}
+						<TEModalBody>Modal body text goes here.</TEModalBody>
+						<TEModalFooter>
+							<TERipple rippleColor="light">
+								<button
+									type="button"
+									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
+									onClick={() => setShowModal(false)}
+								>
+									Close
+								</button>
+							</TERipple>
+							<TERipple rippleColor="light">
+								<button
+									type="button"
+									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
+								>
+									Save changes
+								</button>
+							</TERipple>
+						</TEModalFooter>
+					</TEModalContent>
+				</TEModalDialog>
+			</TEModal>
+		</div>
+	);
+}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -5,6 +5,7 @@ import {
 	TEModalContent,
 	TEModalBody,
 } from 'tw-elements-react';
+import Button from '../components/Button';
 
 export function Modal({
 	showModal,
@@ -15,12 +16,27 @@ export function Modal({
 	return (
 		<div>
 			<TEModal show={showModal} setShow={setShowModal}>
-				<TEModalDialog className="pt-64 px-10">
-					<TEModalContent className="rounded-3xl">
-						<TEModalBody className="flex flex-col justify-center bg-green rounded-2xl p-10">
+				<TEModalDialog className="pt-96 px-10">
+					<TEModalContent className="rounded-2xl">
+						<TEModalBody className="flex flex-col justify-center p-10 dark:bg-light-blue dark:rounded-2xl">
 							{modalBody}
-							{/* <!--TODO: Finish styling after merging button component --> */}
-							<div className="flex justify-center bg-green pt-8 px-8">
+							<div className="flex justify-center pt-8 px-8">
+								<Button
+									text="CANCEL"
+									variant="secondaryCancel"
+									type="button"
+									onClick={() => setShowModal(false)}
+									className="text-2xl mb-3 mr-2 sm:mr-3"
+								/>
+								<Button
+									text="CONFIRM"
+									variant="secondaryConfirm"
+									type="button"
+									onClick={confirmationAction}
+									className="text-2xl mb-3 ml-2 sm:ml-3"
+								/>
+							</div>
+							{/* <div className="flex justify-center bg-green pt-8 px-8">
 								<button
 									type="button"
 									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
@@ -35,7 +51,7 @@ export function Modal({
 								>
 									Confirm
 								</button>
-							</div>
+							</div> */}
 						</TEModalBody>
 					</TEModalContent>
 				</TEModalDialog>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -9,7 +9,7 @@ import {
 	TEModalFooter,
 } from 'tw-elements-react';
 
-export default function Modal() {
+export function Modal() {
 	const [showModal, setShowModal] = useState(false);
 
 	return (

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
 	TERipple,
 	TEModal,
@@ -9,22 +9,9 @@ import {
 	TEModalFooter,
 } from 'tw-elements-react';
 
-export function Modal() {
-	const [showModal, setShowModal] = useState(false);
-
+export function Modal({ showModal, setShowModal, confirmationAction }) {
 	return (
 		<div>
-			{/* <!-- Button trigger modal --> */}
-			<TERipple rippleColor="white">
-				<button
-					type="button"
-					className="inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
-					onClick={() => setShowModal(true)}
-				>
-					Launch demo modal
-				</button>
-			</TERipple>
-
 			{/* <!-- Modal --> */}
 			<TEModal show={showModal} setShow={setShowModal}>
 				<TEModalDialog>
@@ -58,7 +45,7 @@ export function Modal() {
 							</button>
 						</TEModalHeader>
 						{/* <!--Modal body--> */}
-						<TEModalBody>Modal body text goes here.</TEModalBody>
+						<TEModalBody>Are you sure you want to leave this list?</TEModalBody>
 						<TEModalFooter>
 							<TERipple rippleColor="light">
 								<button
@@ -66,15 +53,16 @@ export function Modal() {
 									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
 									onClick={() => setShowModal(false)}
 								>
-									Close
+									Cancel
 								</button>
 							</TERipple>
 							<TERipple rippleColor="light">
 								<button
 									type="button"
 									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
+									onClick={confirmationAction}
 								>
-									Save changes
+									Confirm
 								</button>
 							</TERipple>
 						</TEModalFooter>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -18,19 +18,19 @@ export function Modal({
 			<TEModal show={showModal} setShow={setShowModal}>
 				<TEModalDialog className="pt-96 px-10">
 					<TEModalContent className="rounded-2xl">
-						<TEModalBody className="flex flex-col justify-center p-10 dark:bg-light-blue dark:rounded-2xl">
+						<TEModalBody className="flex flex-col justify-center p-10 dark:bg-yellow dark:rounded-2xl">
 							{modalBody}
 							<div className="flex justify-center pt-8 px-8">
 								<Button
 									text="CANCEL"
-									variant="secondaryCancel"
+									variant="secondary"
 									type="button"
 									onClick={() => setShowModal(false)}
 									className="text-2xl mb-3 mr-2 sm:mr-3"
 								/>
 								<Button
 									text="CONFIRM"
-									variant="secondaryConfirm"
+									variant="primarySmall"
 									type="button"
 									onClick={confirmationAction}
 									className="text-2xl mb-3 ml-2 sm:ml-3"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
-
+import 'tw-elements-react/dist/css/tw-elements-react.min.css';
 import './index.css';
 
 const root = createRoot(document.getElementById('root'));

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -2,6 +2,7 @@ import './Home.css';
 import { useNavigate } from 'react-router-dom';
 import { createNewList } from '../api/firebase';
 import { useState } from 'react';
+import { Modal } from '../components/Modal';
 import { checkIfListExists } from '../api/firebase';
 import { RoughNotation } from 'react-rough-notation';
 
@@ -12,8 +13,26 @@ export function Home({ createToken, setListToken }) {
 	const [createListMessage, setCreateListMessage] = useState('');
 	const [existingListMessage, setExistingListMessage] = useState('');
 	const [tokenInput, setTokenInput] = useState('');
+	const [showModal, setShowModal] = useState(false);
 	const [showRoughNotation, setShowRoughNotation] = useState(false);
 	const messageColor = 'FF0000';
+
+	const modalBody = (
+		<>
+			{/* <!--TODO: Restyle input display using standardized inputs ? --> */}
+			<form>
+				<label htmlFor="tokenInput">Enter List Token</label>
+				<br />
+				<input
+					type="text"
+					id="tokenInput"
+					value={tokenInput}
+					onChange={handleTokenInputChange}
+					placeholder="Enter token"
+				/>
+			</form>
+		</>
+	);
 
 	async function handleCreateClick() {
 		let listId = createToken();
@@ -35,6 +54,7 @@ export function Home({ createToken, setListToken }) {
 
 	async function handleTokenInputFormSubmit(e) {
 		e.preventDefault();
+		setShowModal(false);
 
 		if (!tokenInput) {
 			setExistingListMessage('Please enter a token.');
@@ -53,6 +73,7 @@ export function Home({ createToken, setListToken }) {
 			setTokenInput('');
 		}
 	}
+
 	function handleTokenInputChange(e) {
 		setTokenInput(e.target.value);
 	}
@@ -92,22 +113,15 @@ export function Home({ createToken, setListToken }) {
 					</RoughNotation>
 				)}
 			</div>
-			<form onSubmit={handleTokenInputFormSubmit}>
-				<label htmlFor="tokenInput">Enter existing list token:</label>
-				<br />
-				<input
-					type="text"
-					id="tokenInput"
-					value={tokenInput}
-					onChange={handleTokenInputChange}
-					placeholder="Enter token"
-				/>
-				<br />
-				<button type="submit">Join existing list</button>
-				<br />
-			</form>
+			<button onClick={() => setShowModal(true)}>Join existing list</button>
 			<br />
 			<button onClick={handleCreateClick}>Create a new list</button>
+			<Modal
+				showModal={showModal}
+				setShowModal={setShowModal}
+				modalBody={modalBody}
+				confirmationAction={handleTokenInputFormSubmit}
+			/>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -19,16 +19,21 @@ export function Home({ createToken, setListToken }) {
 
 	const modalBody = (
 		<>
-			{/* <!--TODO: Restyle input display using standardized inputs ? --> */}
-			<form>
-				<label htmlFor="tokenInput">Enter List Token</label>
-				<br />
+			{/* <!--TODO: Finish styling after merging input PR --> */}
+			<form className="flex flex-col justify-center">
+				<label
+					htmlFor="tokenInput"
+					className="flex justify-center text-center text-white pb-6"
+				>
+					ENTER LIST TOKEN
+				</label>
 				<input
 					type="text"
 					id="tokenInput"
+					className="flex justify-center text-center"
 					value={tokenInput}
 					onChange={handleTokenInputChange}
-					placeholder="Enter token"
+					placeholder="my list token"
 				/>
 			</form>
 		</>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -22,29 +22,28 @@ export function Home({ createToken, setListToken }) {
 
 	const modalBody = (
 		<>
-			{/* <!--TODO: Finish styling after merging input PR --> */}
-			<form className="flex flex-col justify-center items-center">
+			<form className="flex flex-col items-center">
 				<label
 					htmlFor="tokenInput"
-					className="flex justify-center text-center text-white pb-6 px-3 mt-2"
+					className="flex text-center dark:text-black pb-6 px-3 mt-4"
 				>
 					ENTER LIST TOKEN
 				</label>
-        <div className="w-full sm:w-1/2 flex items-center border-2 rounded-lg py-2 px-3 sm:px-5">
-          <FontAwesomeIcon
-            icon={key}
-            title="Enter item name"
-            className="text-gray-500 mr-2 sm:mr-4"
-          />
-          <input
-            type="text"
-            id="tokenInput"
-            className="flex-grow border-none outline-none bg-transparent text-center"
-            value={tokenInput}
-            onChange={handleTokenInputChange}
-            placeholder="my list token"
-          />
-        </div>
+				<div className="w-full sm:w-4/5 flex items-center border-2 rounded-lg py-2 px-3 sm:px-5 dark:bg-white">
+					<FontAwesomeIcon
+						icon={key}
+						title="Enter item name"
+						className="text-gray-500 mr-2 sm:mr-4"
+					/>
+					<input
+						type="text"
+						id="tokenInput"
+						className="flex-grow border-none outline-none bg-transparent text-center text-2xl mr-14 dark:placeholder:text-green"
+						value={tokenInput}
+						onChange={handleTokenInputChange}
+						placeholder="my list token"
+					/>
+				</div>
 			</form>
 		</>
 	);
@@ -129,19 +128,19 @@ export function Home({ createToken, setListToken }) {
 					</RoughNotation>
 				)}
 			</div>
-      <div className="flex flex-col items-center gap-10">
-        <Button
-          onClick={(e) => handleCreateClick(e)}
-          text="CREATE LIST"
-          className="max-w-4xl"
-        />
-        <button
-          onClick={() => setShowModal(true)}
-          className="underline underline-offset-8 font-semibold text-green dark:text-light-green"
-        >
-          Join existing list
-        </button>
-      </div>
+			<div className="flex flex-col items-center gap-10">
+				<Button
+					onClick={(e) => handleCreateClick(e)}
+					text="CREATE LIST"
+					className="max-w-4xl"
+				/>
+				<button
+					onClick={() => setShowModal(true)}
+					className="underline underline-offset-8 font-semibold text-green dark:text-light-green"
+				>
+					Join existing list
+				</button>
+			</div>
 			<Modal
 				showModal={showModal}
 				setShowModal={setShowModal}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -10,6 +10,8 @@ import {
 	faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { faClipboard as clipboard } from '@fortawesome/free-regular-svg-icons';
+import copy from 'clipboard-copy';
 
 export function Layout({ listToken, setListToken }) {
 	const location = useLocation();
@@ -21,19 +23,57 @@ export function Layout({ listToken, setListToken }) {
 		setShowModal(false);
 	};
 
+	const CopyToken = () => {
+		const [copied, setCopied] = useState(false);
+
+		const handleCopyToClipboard = async () => {
+			try {
+				await copy(listToken);
+				setCopied(true);
+
+				setTimeout(() => {
+					setCopied(false);
+				}, 3000);
+			} catch (err) {
+				console.error('Copy failed:', err);
+			}
+		};
+
+		return (
+			<>
+				<button onClick={handleCopyToClipboard}>
+					<FontAwesomeIcon icon={clipboard} title="Copy to clipboard" />
+				</button>
+				{copied ? <p className="text-red pl-2">Copied!</p> : null}
+			</>
+		);
+	};
+
 	const modalBody = (
 		<>
 			<div className="flex flex-col items-center">
 				<p className="flex text-center dark:text-black pb-8 px-3 mt-4">
 					Are you sure you want to leave this list?
 				</p>
-				{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+				{/* <div className="flex justify-center items-center text-green dark:text-black">
+					<p className="flex text-center text-4xl font-extrabold pr-3">
+						{listToken}
+					</p>
+					<CopyToken/>
+				</div>
+				<p className="text-green dark:text-black text-center italic pt-2 pb-4">
+					Copy your list token for next time!
+				</p> */}
+
 				<p className="flex text-center text-4xl font-extrabold text-green dark:text-black">
 					{listToken}
 				</p>
-				<p className="text-green dark:text-black text-center italic pt-2 pb-4">
-					Save your list token for next time!
-				</p>
+				<div className="flex justify-center items-center text-green dark:text-black pt-2 pb-4 ">
+					<p className="text-green dark:text-black text-center italic pr-3">
+						Copy your list token for next time
+					</p>
+					<CopyToken />
+				</div>
 			</div>
 		</>
 	);

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -7,8 +7,20 @@ import {
 	faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { Modal } from '../components/Modal';
+import { useState } from 'react';
+import {
+	TERipple,
+	TEModal,
+	TEModalDialog,
+	TEModalContent,
+	TEModalHeader,
+	TEModalBody,
+	TEModalFooter,
+} from 'tw-elements-react';
 
 export function Layout({ setListToken }) {
+	const [showModal, setShowModal] = useState(false);
 	const location = useLocation();
 
 	const removeListToken = () => {
@@ -82,11 +94,68 @@ export function Layout({ setListToken }) {
 								title="Leave list"
 								className="text-black"
 								type="button"
-								onClick={removeListToken}
+								// onClick={removeListToken}
+								onClick={() => setShowModal(true)}
 							/>
 							<p className="text-lg text-black">LEAVE LIST</p>
 							<br />
 						</NavLink>
+
+						{/* <TEModal show={showModal} setShow={setShowModal}>
+				<TEModalDialog>
+					<TEModalContent>
+						<TEModalHeader>
+							
+							<h5 className="text-xl font-medium leading-normal text-neutral-800 dark:text-neutral-200">
+								Modal title
+							</h5>
+							
+							<button
+								type="button"
+								className="box-content rounded-none border-none hover:no-underline hover:opacity-75 focus:opacity-100 focus:shadow-none focus:outline-none"
+								onClick={() => setShowModal(false)}
+								aria-label="Close"
+							>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									viewBox="0 0 24 24"
+									strokeWidth="1.5"
+									stroke="currentColor"
+									className="h-6 w-6"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							</button>
+						</TEModalHeader>
+						
+						<TEModalBody>Modal body text goes here.</TEModalBody>
+						<TEModalFooter>
+							<TERipple rippleColor="light">
+								<button
+									type="button"
+									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
+									onClick={() => setShowModal(false)}
+								>
+									Close
+								</button>
+							</TERipple>
+							<TERipple rippleColor="light">
+								<button
+									type="button"
+									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
+								>
+									Save changes
+								</button>
+							</TERipple>
+						</TEModalFooter>
+					</TEModalContent>
+				</TEModalDialog>
+			</TEModal> */}
 					</div>
 				);
 			}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
-export function Layout({ setListToken, showModal, setShowModal }) {
+export function Layout({ listToken, setListToken, showModal, setShowModal }) {
 	const location = useLocation();
 
 	const removeListToken = () => {
@@ -17,8 +17,6 @@ export function Layout({ setListToken, showModal, setShowModal }) {
 		setListToken(null);
 		setShowModal(false);
 	};
-
-	const listToken = localStorage.getItem('tcl-shopping-list-token');
 
 	const renderNavBar = () => {
 		if (!listToken) {
@@ -46,61 +44,57 @@ export function Layout({ setListToken, showModal, setShowModal }) {
 					</p>
 				</div>
 			);
-		} else {
-			if (listToken) {
-				return (
-					<>
-						<div className="Nav-container -mt-4">
-							<NavLink
-								to="/list"
-								className={`Nav-link ${
-									location.pathname === '/list' ? 'underline text-black' : ''
-								}`}
-							>
-								<FontAwesomeIcon
-									icon={faList}
-									title="Navigate to list page"
-									className="text-black"
-								/>
-								<br />
-								<p className="text-lg text-black">VIEW LIST</p>
-							</NavLink>
-							<NavLink
-								to="/add-item"
-								className={`Nav-link ${
-									location.pathname === '/add-item'
-										? 'underline text-black'
-										: ''
-								}`}
-							>
-								<FontAwesomeIcon
-									icon={faPlus}
-									title="Navigate to the add item page"
-									className="text-black"
-								/>
-								<br />
-								<p className="text-lg text-black">ADD ITEM</p>
-							</NavLink>
-							<NavLink className="Nav-link">
-								<FontAwesomeIcon
-									icon={faRightFromBracket}
-									title="Leave list"
-									className="text-black"
-									type="button"
-									onClick={() => setShowModal(true)}
-								/>
-								<p className="text-lg text-black">LEAVE LIST</p>
-								<br />
-							</NavLink>
-						</div>
-						<Modal
-							showModal={showModal}
-							setShowModal={setShowModal}
-							confirmationAction={removeListToken}
-						/>
-					</>
-				);
-			}
+		} else if (listToken) {
+			return (
+				<>
+					<div className="Nav-container -mt-4">
+						<NavLink
+							to="/list"
+							className={`Nav-link ${
+								location.pathname === '/list' ? 'underline text-black' : ''
+							}`}
+						>
+							<FontAwesomeIcon
+								icon={faList}
+								title="Navigate to list page"
+								className="text-black"
+							/>
+							<br />
+							<p className="text-lg text-black">VIEW LIST</p>
+						</NavLink>
+						<NavLink
+							to="/add-item"
+							className={`Nav-link ${
+								location.pathname === '/add-item' ? 'underline text-black' : ''
+							}`}
+						>
+							<FontAwesomeIcon
+								icon={faPlus}
+								title="Navigate to the add item page"
+								className="text-black"
+							/>
+							<br />
+							<p className="text-lg text-black">ADD ITEM</p>
+						</NavLink>
+						<NavLink className="Nav-link">
+							<FontAwesomeIcon
+								icon={faRightFromBracket}
+								title="Leave list"
+								className="text-black"
+								type="button"
+								onClick={() => setShowModal(true)}
+							/>
+							<p className="text-lg text-black">LEAVE LIST</p>
+							<br />
+						</NavLink>
+					</div>
+					<Modal
+						showModal={showModal}
+						setShowModal={setShowModal}
+						confirmationAction={removeListToken}
+					/>
+				</>
+			);
 		}
 	};
 

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -22,10 +22,15 @@ export function Layout({ listToken, setListToken }) {
 
 	const modalBody = (
 		<>
-			Are you sure you want to leave this list?
-			<br />
-			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
-			{listToken}
+			<div className="flex flex-col justify-center">
+				<p className="flex justify-center text-center text-white pb-6">
+					Are you sure you want to leave this list?
+				</p>
+				{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+				<p className="flex justify-center text-center text-white">
+					{listToken}
+				</p>
+			</div>
 		</>
 	);
 

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,4 +1,5 @@
 import { Outlet, NavLink, useLocation } from 'react-router-dom';
+import { Modal } from '../components/Modal';
 import './Layout.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -7,25 +8,14 @@ import {
 	faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
-import { Modal } from '../components/Modal';
-import { useState } from 'react';
-import {
-	TERipple,
-	TEModal,
-	TEModalDialog,
-	TEModalContent,
-	TEModalHeader,
-	TEModalBody,
-	TEModalFooter,
-} from 'tw-elements-react';
 
-export function Layout({ setListToken }) {
-	const [showModal, setShowModal] = useState(false);
+export function Layout({ setListToken, showModal, setShowModal }) {
 	const location = useLocation();
 
 	const removeListToken = () => {
 		localStorage.removeItem('tcl-shopping-list-token');
 		setListToken(null);
+		setShowModal(false);
 	};
 
 	const listToken = localStorage.getItem('tcl-shopping-list-token');
@@ -59,104 +49,56 @@ export function Layout({ setListToken }) {
 		} else {
 			if (listToken) {
 				return (
-					<div className="Nav-container -mt-4">
-						<NavLink
-							to="/list"
-							className={`Nav-link ${
-								location.pathname === '/list' ? 'underline text-black' : ''
-							}`}
-						>
-							<FontAwesomeIcon
-								icon={faList}
-								title="Navigate to list page"
-								className="text-black"
-							/>
-							<br />
-							<p className="text-lg text-black">VIEW LIST</p>
-						</NavLink>
-						<NavLink
-							to="/add-item"
-							className={`Nav-link ${
-								location.pathname === '/add-item' ? 'underline text-black' : ''
-							}`}
-						>
-							<FontAwesomeIcon
-								icon={faPlus}
-								title="Navigate to the add item page"
-								className="text-black"
-							/>
-							<br />
-							<p className="text-lg text-black">ADD ITEM</p>
-						</NavLink>
-						<NavLink className="Nav-link">
-							<FontAwesomeIcon
-								icon={faRightFromBracket}
-								title="Leave list"
-								className="text-black"
-								type="button"
-								// onClick={removeListToken}
-								onClick={() => setShowModal(true)}
-							/>
-							<p className="text-lg text-black">LEAVE LIST</p>
-							<br />
-						</NavLink>
-
-						{/* <TEModal show={showModal} setShow={setShowModal}>
-				<TEModalDialog>
-					<TEModalContent>
-						<TEModalHeader>
-							
-							<h5 className="text-xl font-medium leading-normal text-neutral-800 dark:text-neutral-200">
-								Modal title
-							</h5>
-							
-							<button
-								type="button"
-								className="box-content rounded-none border-none hover:no-underline hover:opacity-75 focus:opacity-100 focus:shadow-none focus:outline-none"
-								onClick={() => setShowModal(false)}
-								aria-label="Close"
+					<>
+						<div className="Nav-container -mt-4">
+							<NavLink
+								to="/list"
+								className={`Nav-link ${
+									location.pathname === '/list' ? 'underline text-black' : ''
+								}`}
 							>
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									fill="none"
-									viewBox="0 0 24 24"
-									strokeWidth="1.5"
-									stroke="currentColor"
-									className="h-6 w-6"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										d="M6 18L18 6M6 6l12 12"
-									/>
-								</svg>
-							</button>
-						</TEModalHeader>
-						
-						<TEModalBody>Modal body text goes here.</TEModalBody>
-						<TEModalFooter>
-							<TERipple rippleColor="light">
-								<button
+								<FontAwesomeIcon
+									icon={faList}
+									title="Navigate to list page"
+									className="text-black"
+								/>
+								<br />
+								<p className="text-lg text-black">VIEW LIST</p>
+							</NavLink>
+							<NavLink
+								to="/add-item"
+								className={`Nav-link ${
+									location.pathname === '/add-item'
+										? 'underline text-black'
+										: ''
+								}`}
+							>
+								<FontAwesomeIcon
+									icon={faPlus}
+									title="Navigate to the add item page"
+									className="text-black"
+								/>
+								<br />
+								<p className="text-lg text-black">ADD ITEM</p>
+							</NavLink>
+							<NavLink className="Nav-link">
+								<FontAwesomeIcon
+									icon={faRightFromBracket}
+									title="Leave list"
+									className="text-black"
 									type="button"
-									className="inline-block rounded bg-primary-100 px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-primary-700 transition duration-150 ease-in-out hover:bg-primary-accent-100 focus:bg-primary-accent-100 focus:outline-none focus:ring-0 active:bg-primary-accent-200"
-									onClick={() => setShowModal(false)}
-								>
-									Close
-								</button>
-							</TERipple>
-							<TERipple rippleColor="light">
-								<button
-									type="button"
-									className="ml-1 inline-block rounded bg-primary px-6 pb-2 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-[0_4px_9px_-4px_#3b71ca] transition duration-150 ease-in-out hover:bg-primary-600 hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:bg-primary-600 focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] focus:outline-none focus:ring-0 active:bg-primary-700 active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.3),0_4px_18px_0_rgba(59,113,202,0.2)] dark:shadow-[0_4px_9px_-4px_rgba(59,113,202,0.5)] dark:hover:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:focus:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)] dark:active:shadow-[0_8px_9px_-4px_rgba(59,113,202,0.2),0_4px_18px_0_rgba(59,113,202,0.1)]"
-								>
-									Save changes
-								</button>
-							</TERipple>
-						</TEModalFooter>
-					</TEModalContent>
-				</TEModalDialog>
-			</TEModal> */}
-					</div>
+									onClick={() => setShowModal(true)}
+								/>
+								<p className="text-lg text-black">LEAVE LIST</p>
+								<br />
+							</NavLink>
+						</div>
+						<Modal
+							showModal={showModal}
+							setShowModal={setShowModal}
+							confirmationAction={removeListToken}
+						/>
+					</>
 				);
 			}
 		}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -23,13 +23,16 @@ export function Layout({ listToken, setListToken }) {
 
 	const modalBody = (
 		<>
-			<div className="flex flex-col justify-center">
-				<p className="flex justify-center text-center text-white pb-6">
+			<div className="flex flex-col items-center">
+				<p className="flex text-center dark:text-black pb-8 px-3 mt-4">
 					Are you sure you want to leave this list?
 				</p>
 				{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
-				<p className="flex justify-center text-center text-white">
+				<p className="flex text-center text-4xl font-extrabold text-green dark:text-black">
 					{listToken}
+				</p>
+				<p className="text-green dark:text-black text-center italic pt-2 pb-4">
+					Save your list token for next time!
 				</p>
 			</div>
 		</>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -18,6 +18,15 @@ export function Layout({ listToken, setListToken, showModal, setShowModal }) {
 		setShowModal(false);
 	};
 
+	const modalBody = (
+		<>
+			Are you sure you want to leave this list?
+			<br />
+			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+			{listToken}
+		</>
+	);
+
 	const renderNavBar = () => {
 		if (!listToken) {
 			return (
@@ -76,13 +85,11 @@ export function Layout({ listToken, setListToken, showModal, setShowModal }) {
 							<br />
 							<p className="text-lg text-black">ADD ITEM</p>
 						</NavLink>
-						<NavLink className="Nav-link">
+						<NavLink className="Nav-link" onClick={() => setShowModal(true)}>
 							<FontAwesomeIcon
 								icon={faRightFromBracket}
 								title="Leave list"
 								className="text-black"
-								type="button"
-								onClick={() => setShowModal(true)}
 							/>
 							<p className="text-lg text-black">LEAVE LIST</p>
 							<br />
@@ -91,6 +98,7 @@ export function Layout({ listToken, setListToken, showModal, setShowModal }) {
 					<Modal
 						showModal={showModal}
 						setShowModal={setShowModal}
+						modalBody={modalBody}
 						confirmationAction={removeListToken}
 					/>
 				</>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,4 +1,5 @@
 import { Outlet, NavLink, useLocation } from 'react-router-dom';
+import { useState } from 'react';
 import { Modal } from '../components/Modal';
 import './Layout.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,8 +10,9 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
-export function Layout({ listToken, setListToken, showModal, setShowModal }) {
+export function Layout({ listToken, setListToken }) {
 	const location = useLocation();
+	const [showModal, setShowModal] = useState(false);
 
 	const removeListToken = () => {
 		localStorage.removeItem('tcl-shopping-list-token');

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -44,7 +44,9 @@ export function Layout({ listToken, setListToken }) {
 				<button onClick={handleCopyToClipboard}>
 					<FontAwesomeIcon icon={clipboard} title="Copy to clipboard" />
 				</button>
-				{copied ? <p className="text-red pl-2">Copied!</p> : null}
+				{copied ? (
+					<p className="text-red dark:text-black pl-2">Copied!</p>
+				) : null}
 			</>
 		);
 	};
@@ -55,16 +57,6 @@ export function Layout({ listToken, setListToken }) {
 				<p className="flex text-center dark:text-black pb-8 px-3 mt-4">
 					Are you sure you want to leave this list?
 				</p>
-				{/* <div className="flex justify-center items-center text-green dark:text-black">
-					<p className="flex text-center text-4xl font-extrabold pr-3">
-						{listToken}
-					</p>
-					<CopyToken/>
-				</div>
-				<p className="text-green dark:text-black text-center italic pt-2 pb-4">
-					Copy your list token for next time!
-				</p> */}
-
 				<p className="flex text-center text-4xl font-extrabold text-green dark:text-black">
 					{listToken}
 				</p>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -7,15 +7,17 @@ import copy from 'clipboard-copy';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClipboard as clipboard } from '@fortawesome/free-regular-svg-icons';
 
-export function List({ data, listId, showModal, setShowModal }) {
+export function List({ data, listId }) {
 	const navigate = useNavigate();
 	const [itemToDelete, setItemToDelete] = useState('');
+	const [showModal, setShowModal] = useState(false);
 
 	const modalBody = (
 		<>
 			Are you sure you want to delete this item?
 			<br />
 			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+			{/* {itemToDelete} */}
 		</>
 	);
 
@@ -126,7 +128,6 @@ export function List({ data, listId, showModal, setShowModal }) {
 					dateNextPurchased={item.dateNextPurchased}
 					dateCreated={item.dateCreated}
 					urgency={itemUrgency}
-					showModal={showModal}
 					setShowModal={setShowModal}
 					setItemToDelete={setItemToDelete}
 				/>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -9,7 +9,7 @@ import { faClipboard as clipboard } from '@fortawesome/free-regular-svg-icons';
 
 export function List({ data, listId }) {
 	const navigate = useNavigate();
-	const [itemToDelete, setItemToDelete] = useState('');
+	const [itemToDelete, setItemToDelete] = useState({ itemId: '', name: '' });
 	const [showModal, setShowModal] = useState(false);
 
 	const modalBody = (
@@ -17,14 +17,15 @@ export function List({ data, listId }) {
 			Are you sure you want to delete this item?
 			<br />
 			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
-			{/* {itemToDelete} */}
+			{itemToDelete.name}
 		</>
 	);
 
 	const handleDelete = async (e) => {
-		console.log(itemToDelete);
+		console.log(itemToDelete.itemId);
+		console.log(itemToDelete.name);
 		console.log(listId);
-		await deleteItem(listId, itemToDelete);
+		await deleteItem(listId, itemToDelete.itemId);
 		setShowModal(false);
 	};
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -13,12 +13,15 @@ export function List({ data, listId }) {
 	const [showModal, setShowModal] = useState(false);
 
 	const modalBody = (
-		<>
-			Are you sure you want to delete this item?
-			<br />
+		<div className="flex flex-col justify-center">
+			<p className="flex justify-center text-center text-white pb-6">
+				Are you sure you want to delete this item?
+			</p>
 			{/* <!--TODO: Restyle name display using standardized inputs ? --> */}
-			{itemToDelete.name}
-		</>
+			<p className="flex justify-center text-center text-white">
+				{itemToDelete.name}
+			</p>
+		</div>
 	);
 
 	const handleDelete = async (e) => {

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,14 +1,30 @@
 import { ListItem } from '../components';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { comparePurchaseUrgency } from '../api/firebase';
-
+import { comparePurchaseUrgency, deleteItem } from '../api/firebase';
+import { Modal } from '../components/Modal';
 import copy from 'clipboard-copy';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClipboard as clipboard } from '@fortawesome/free-regular-svg-icons';
 
-export function List({ data, listId }) {
+export function List({ data, listId, showModal, setShowModal }) {
 	const navigate = useNavigate();
+	const [itemToDelete, setItemToDelete] = useState('');
+
+	const modalBody = (
+		<>
+			Are you sure you want to delete this item?
+			<br />
+			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+		</>
+	);
+
+	const handleDelete = async (e) => {
+		console.log(itemToDelete);
+		console.log(listId);
+		await deleteItem(listId, itemToDelete);
+		setShowModal(false);
+	};
 
 	const WelcomePrompt = () => {
 		return (
@@ -110,6 +126,9 @@ export function List({ data, listId }) {
 					dateNextPurchased={item.dateNextPurchased}
 					dateCreated={item.dateCreated}
 					urgency={itemUrgency}
+					showModal={showModal}
+					setShowModal={setShowModal}
+					setItemToDelete={setItemToDelete}
 				/>
 			) : null;
 		});
@@ -151,6 +170,12 @@ export function List({ data, listId }) {
 		<>
 			<CopyToken />
 			{data.length > 1 ? <FormAndList /> : <WelcomePrompt />}
+			<Modal
+				showModal={showModal}
+				setShowModal={setShowModal}
+				modalBody={modalBody}
+				confirmationAction={handleDelete}
+			/>
 		</>
 	);
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -70,7 +70,7 @@ export function List({ data, listId }) {
 						<FontAwesomeIcon icon={clipboard} title="Copy to clipboard" />
 					</button>
 				</span>
-				{copied ? <p>Copied!</p> : null}
+				{copied ? <p className="text-red">Copied!</p> : null}
 			</div>
 		);
 	};

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -16,15 +16,12 @@ export function List({ data, listId }) {
 		<>
 			Are you sure you want to delete this item?
 			<br />
-			{/* <!--TODO: Restyle listToken display using standardized inputs ? --> */}
+			{/* <!--TODO: Restyle name display using standardized inputs ? --> */}
 			{itemToDelete.name}
 		</>
 	);
 
 	const handleDelete = async (e) => {
-		console.log(itemToDelete.itemId);
-		console.log(itemToDelete.name);
-		console.log(listId);
 		await deleteItem(listId, itemToDelete.itemId);
 		setShowModal(false);
 	};

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,6 +2,7 @@ import { ListItem } from '../components';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { comparePurchaseUrgency, deleteItem } from '../api/firebase';
+import { Modal } from '../components/Modal';
 import Button from '../components/Button';
 import copy from 'clipboard-copy';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -15,12 +15,11 @@ export function List({ data, listId }) {
 	const [showModal, setShowModal] = useState(false);
 
 	const modalBody = (
-		<div className="flex flex-col justify-center">
-			<p className="flex justify-center text-center text-white pb-6">
+		<div className="flex flex-col items-center">
+			<p className="flex text-center dark:text-black pb-6 px-3 mt-4">
 				Are you sure you want to delete this item?
 			</p>
-			{/* <!--TODO: Restyle name display using standardized inputs ? --> */}
-			<p className="flex justify-center text-center text-white">
+			<p className="flex text-center text-4xl font-extrabold text-green dark:text-black pb-2">
 				{itemToDelete.name}
 			</p>
 		</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-	content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+	content: [
+		'./index.html',
+		'./src/**/*.{js,ts,jsx,tsx}',
+		'./node_modules/tw-elements-react/dist/js/**/*.js',
+	],
 	theme: {
 		extend: {
 			colors: {
@@ -11,5 +15,5 @@ export default {
 			},
 		},
 	},
-	plugins: [],
+	plugins: [require('tw-elements-react/dist/plugin.cjs')],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,10 @@ export default {
 				yellow: '#FFDE30',
 				'light-blue': '#8AD0C3',
 				red: '#E36849',
-				green: '#137C78',
+				green: {
+					DEFAULT: '#137C78',
+					dark: '#1fa39e',
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## Description

~~ **STATUS UPDATE: PR IS FINALIZED** ~~ 

Create a reusable modal component to use for multiple actions, styled to match our wireframes and design.

Each modal has a `Cancel` and a `Confirm` button. To make the modal dynamic, the component takes in a `modalBody` prop for what to display in the modal, and a `confirmationAction` prop for what action the confirm button triggers. It uses the `showModal` hook (native to the library used) to control when the modal is shown vs hidden. The modals are also responsive to work for all screen sizes.

## Related Issue

Closes #38 

## Acceptance Criteria

- [x] A modal component is added
- [x] A modal is used for `Enter list token` action (to open a list)
- [x] A modal is used for `Log out` of current list
- [x] A modal is used for `Delete Item` to remove an item from the list (this replaces the original `window.confirm` popup)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
| ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
| ✓   | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

- Installed [Tailwind Elements React library](https://tailwind-elements.com/docs/react/) to make the [modal component](https://tailwind-elements.com/docs/react/components/modal/)
- Added trash can icon to the ListItem component to use for `Delete` button
- The old `window.confirm` popup for deleting an item has been replaced with a modal
- All three modals are fully functional, and should be fully accessible
- Slight refactoring was required in order for modals to correctly render and work. For example, `handleDelete` function now lives in the List component, instead of ListItem)
- In "Leave list" modal: Added a copy button to match the List page. Added a reminder to users to save their token for later.
- Styled modals to use the secondary `Buttons` and match input styling on rest of the app.

### After

<!-- If UI feature, take provide screenshots -->

https://github.com/the-collab-lab/tcl-64-smart-shopping-list/assets/121128718/50149ce2-cd29-420e-a4be-f5d137656d00

## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
In the app, test user flows for these scenarios:
- From the Home page, use `join existing list` button to enter an existing token in order to log in
- From the Home page, use `join existing list` button but then choose `Cancel` instead of `Confirm`
- From the List page, use `delete` icon button to remove an item from the list
- From any page, use `leave list` button to log out
- Repeat any of these using the keyboard to navigate instead of the mouse
